### PR TITLE
Fixing a typo and referencing a class

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -53,8 +53,8 @@ Basecamp::templates()->destroy($id);
 
 ```php
 $projectConstruction = $template->projectConstructions()->store([
-    'name': 'Marketing ',
-    'description': '2016-2017 Strategy',
+    'name' => 'Marketing ',
+    'description' => '2016-2017 Strategy',
 ]);
 ```
 

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Belvedere\Basecamp\Models;
+use Basecamp;
 
 class Template extends AbstractModel
 {


### PR DESCRIPTION
Fixing a typo in template docs and referencing `Basecamp` class in `Template` model.