### PR TITLE
Updated version constraints for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": ">=7.0",
         "ext-fileinfo": "*",
         "illuminate/support": "^5.5|^6.0",
-        "kevinrob/guzzle-cache-middleware": "^2.1",
+        "kevinrob/guzzle-cache-middleware": "^3.0",
         "illuminate/cache": "^5.5|^6.0",
         "illuminate/filesystem": "^5.5|^6.0",
         "guzzlehttp/guzzle": "^6.3"


### PR DESCRIPTION
Fixes #8:

  Problem 1
    - Conclusion: don't install coopbelvedere/laravel-basecamp-api v1.1.4
    - Conclusion: don't install coopbelvedere/laravel-basecamp-api v1.1.3
    - Conclusion: don't install coopbelvedere/laravel-basecamp-api v1.1.2
    - Conclusion: don't install coopbelvedere/laravel-basecamp-api v1.1.1
    - Installation request for kevinrob/guzzle-cache-middleware (locked at v3.2.1) -> satisfiable by kevinrob/guzzle-cache-middleware[v3.2.1].
    - Conclusion: remove laravel/framework v6.4.1
    - Installation request for coopbelvedere/laravel-basecamp-api ^1.1 -> satisfiable by coopbelvedere/laravel-basecamp-api[1.1.0, v1.1.1, v1.1.2, v1.1.3, v1.1.4].
    - Conclusion: don't install laravel/framework v6.4.1
