### PR TITLE
added project key when creating a project from a template

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -52,9 +52,11 @@ Basecamp::templates()->destroy($id);
 ## Create a project construction
 
 ```php
-$projectConstruction = $template->projectConstructions()->store([
-    'name' => 'Marketing ',
-    'description' => '2016-2017 Strategy',
+$projectConstruction = $template->projectConstructions()->store([ 
+  'project' => [ 
+        'name' => 'Marketing ',
+        'description' => '2016-2017 Strategy',
+   ]
 ]);
 ```
 


### PR DESCRIPTION
When creating a project from an existing template, the payload must be enclosed in a `project` key.

For reference access this [Basecamp API Documentation](https://github.com/basecamp/bc3-api/blob/master/sections/templates.md#create-a-project-construction)